### PR TITLE
feat: добавить перенос записей и комментарии при завершении

### DIFF
--- a/alembic/versions/d4f0e5a6b7c8_add_appointment_reschedule_requests.py
+++ b/alembic/versions/d4f0e5a6b7c8_add_appointment_reschedule_requests.py
@@ -1,0 +1,111 @@
+"""add appointment reschedule requests
+
+Revision ID: d4f0e5a6b7c8
+Revises: 0465de7813f5
+Create Date: 2026-05-09 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "d4f0e5a6b7c8"
+down_revision: Union[str, Sequence[str], None] = "0465de7813f5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "appointment_reschedule_requests",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("appointment_id", sa.UUID(), nullable=False),
+        sa.Column("requested_by_user_id", sa.UUID(), nullable=True),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "pending",
+                "confirmed",
+                "rejected",
+                name="appointmentreschedulestatus",
+            ),
+            nullable=False,
+        ),
+        sa.Column("old_scheduled_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("old_remind_time", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("old_venue", sa.String(length=128), nullable=False),
+        sa.Column("old_comment", sa.String(length=512), nullable=True),
+        sa.Column("requested_scheduled_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("requested_remind_time", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("requested_venue", sa.String(length=128), nullable=True),
+        sa.Column("requested_comment", sa.String(length=512), nullable=True),
+        sa.Column("rejection_comment", sa.String(length=512), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("responded_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["appointment_id"], ["appointments.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["requested_by_user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_appointment_reschedule_requests_id"),
+        "appointment_reschedule_requests",
+        ["id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_appointment_reschedule_requests_appointment_id"),
+        "appointment_reschedule_requests",
+        ["appointment_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_appointment_reschedule_requests_requested_by_user_id"),
+        "appointment_reschedule_requests",
+        ["requested_by_user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_appointment_reschedule_requests_status"),
+        "appointment_reschedule_requests",
+        ["status"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_appointment_reschedule_requests_one_pending_per_appointment",
+        "appointment_reschedule_requests",
+        ["appointment_id"],
+        unique=True,
+        postgresql_where=sa.text("status = 'pending'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_appointment_reschedule_requests_one_pending_per_appointment",
+        table_name="appointment_reschedule_requests",
+    )
+    op.drop_index(
+        op.f("ix_appointment_reschedule_requests_status"),
+        table_name="appointment_reschedule_requests",
+    )
+    op.drop_index(
+        op.f("ix_appointment_reschedule_requests_requested_by_user_id"),
+        table_name="appointment_reschedule_requests",
+    )
+    op.drop_index(
+        op.f("ix_appointment_reschedule_requests_appointment_id"),
+        table_name="appointment_reschedule_requests",
+    )
+    op.drop_index(
+        op.f("ix_appointment_reschedule_requests_id"),
+        table_name="appointment_reschedule_requests",
+    )
+    op.drop_table("appointment_reschedule_requests")
+    sa.Enum(name="appointmentreschedulestatus").drop(op.get_bind(), checkfirst=True)

--- a/alembic/versions/e2f3a4b5c6d7_add_psychologist_comment_to_appointments.py
+++ b/alembic/versions/e2f3a4b5c6d7_add_psychologist_comment_to_appointments.py
@@ -1,0 +1,47 @@
+"""add psychologist comment to appointments
+
+Revision ID: e2f3a4b5c6d7
+Revises: d4f0e5a6b7c8
+Create Date: 2026-05-09 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "e2f3a4b5c6d7"
+down_revision: Union[str, Sequence[str], None] = "d4f0e5a6b7c8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "appointments",
+        "conclusion",
+        existing_type=sa.String(length=2048),
+        existing_nullable=True,
+        comment="Комментарий пациенту",
+    )
+    op.add_column(
+        "appointments",
+        sa.Column(
+            "psychologist_comment",
+            sa.String(length=2048),
+            nullable=True,
+            comment="Комментарий психологам",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("appointments", "psychologist_comment")
+    op.alter_column(
+        "appointments",
+        "conclusion",
+        existing_type=sa.String(length=2048),
+        existing_nullable=True,
+        comment="Заключение психолога",
+    )

--- a/psychohelp/main.py
+++ b/psychohelp/main.py
@@ -24,6 +24,7 @@ from psychohelp.models import (
     applications,
     articles,
     password_reset_tokens,
+    appointment_reschedule_requests,
 )
 
 import uvicorn

--- a/psychohelp/models/__init__.py
+++ b/psychohelp/models/__init__.py
@@ -6,5 +6,6 @@ from psychohelp.models import appointments
 from psychohelp.models import reviews
 from psychohelp.models import articles
 from psychohelp.models import password_reset_tokens
+from psychohelp.models import appointment_reschedule_requests
 from .applications import Application
 from .news import News

--- a/psychohelp/models/appointment_reschedule_requests.py
+++ b/psychohelp/models/appointment_reschedule_requests.py
@@ -1,0 +1,60 @@
+import enum
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, Enum, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from psychohelp.config.config import Base
+
+
+class AppointmentRescheduleStatus(enum.Enum):
+    pending = "pending"
+    confirmed = "confirmed"
+    rejected = "rejected"
+
+
+class AppointmentRescheduleRequest(Base):
+    __tablename__ = "appointment_reschedule_requests"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, index=True, default=uuid.uuid4)
+    appointment_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("appointments.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    requested_by_user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    status = Column(
+        Enum(AppointmentRescheduleStatus),
+        nullable=False,
+        default=AppointmentRescheduleStatus.pending,
+        index=True,
+    )
+
+    old_scheduled_time = Column(DateTime(timezone=True), nullable=False)
+    old_remind_time = Column(DateTime(timezone=True), nullable=True)
+    old_venue = Column(String(128), nullable=False)
+    old_comment = Column(String(512), nullable=True)
+
+    requested_scheduled_time = Column(DateTime(timezone=True), nullable=False)
+    requested_remind_time = Column(DateTime(timezone=True), nullable=True)
+    requested_venue = Column(String(128), nullable=True)
+    requested_comment = Column(String(512), nullable=True)
+
+    rejection_comment = Column(String(512), nullable=True)
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    responded_at = Column(DateTime(timezone=True), nullable=True)
+
+    appointment = relationship("Appointment", back_populates="reschedule_requests")
+    requested_by = relationship("User")

--- a/psychohelp/models/appointments.py
+++ b/psychohelp/models/appointments.py
@@ -61,3 +61,8 @@ class Appointment(Base):
         "Psychologist", foreign_keys=[psychologist_id], back_populates="appointments"
     )
     review = relationship("Review", back_populates="appointment", uselist=False)
+    reschedule_requests = relationship(
+        "AppointmentRescheduleRequest",
+        back_populates="appointment",
+        cascade="all, delete-orphan",
+    )

--- a/psychohelp/models/appointments.py
+++ b/psychohelp/models/appointments.py
@@ -47,7 +47,8 @@ class Appointment(Base):
     reason = Column(String(64), nullable=True)
     status = Column(Enum(AppointmentStatus), nullable=False)
     cancel_reason = Column(String(512), nullable=True, comment="Причина отмены")
-    conclusion = Column(String(2048), nullable=True, comment="Заключение психолога")
+    conclusion = Column(String(2048), nullable=True, comment="Комментарий пациенту")
+    psychologist_comment = Column(String(2048), nullable=True, comment="Комментарий психологам")
     scheduled_time = Column(DateTime(timezone=True), nullable=False, comment="Время назначенной встречи")
     remind_time = Column(DateTime(timezone=True), nullable=True, comment="Время напоминания")
     last_change_time = Column(DateTime(timezone=True), nullable=False, comment="Время последнего изменения")
@@ -66,3 +67,7 @@ class Appointment(Base):
         back_populates="appointment",
         cascade="all, delete-orphan",
     )
+
+    @property
+    def patient_comment(self) -> str | None:
+        return self.conclusion

--- a/psychohelp/repositories/appointment_reschedule_requests.py
+++ b/psychohelp/repositories/appointment_reschedule_requests.py
@@ -1,0 +1,180 @@
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.future import select
+from sqlalchemy.orm import selectinload
+
+from psychohelp.config.config import get_async_db
+from psychohelp.models.appointment_reschedule_requests import (
+    AppointmentRescheduleRequest,
+    AppointmentRescheduleStatus,
+)
+from psychohelp.models.appointments import Appointment, AppointmentStatus
+from psychohelp.models.psychologists import Psychologist
+
+
+def _ensure_appointment_open(appointment: Appointment) -> None:
+    if appointment.status in (AppointmentStatus.done, AppointmentStatus.cancelled):
+        raise ValueError("Нельзя перенести завершенную или отмененную запись")
+
+
+async def create_reschedule_request(
+    appointment_id: UUID,
+    psychologist_user_id: UUID,
+    scheduled_time: datetime,
+    remind_time: datetime | None,
+    venue: str | None,
+    comment: str | None,
+) -> AppointmentRescheduleRequest:
+    async with get_async_db() as session:
+        query = (
+            select(Appointment)
+            .options(selectinload(Appointment.psychologist))
+            .where(Appointment.id == appointment_id)
+        )
+        result = await session.execute(query)
+        appointment = result.scalar_one_or_none()
+
+        if appointment is None:
+            raise ValueError("Встреча не найдена")
+        if appointment.psychologist.user_id != psychologist_user_id:
+            raise PermissionError("Только назначенный психолог может запросить перенос")
+
+        _ensure_appointment_open(appointment)
+
+        pending_result = await session.execute(
+            select(AppointmentRescheduleRequest).where(
+                AppointmentRescheduleRequest.appointment_id == appointment_id,
+                AppointmentRescheduleRequest.status == AppointmentRescheduleStatus.pending,
+            )
+        )
+        if pending_result.scalar_one_or_none() is not None:
+            raise ValueError("По этой записи уже запрошен перенос")
+
+        reschedule_request = AppointmentRescheduleRequest(
+            appointment_id=appointment_id,
+            requested_by_user_id=psychologist_user_id,
+            old_scheduled_time=appointment.scheduled_time,
+            old_remind_time=appointment.remind_time,
+            old_venue=appointment.venue,
+            old_comment=appointment.comment,
+            requested_scheduled_time=scheduled_time,
+            requested_remind_time=remind_time,
+            requested_venue=venue,
+            requested_comment=comment,
+        )
+
+        try:
+            session.add(reschedule_request)
+            await session.commit()
+            await session.refresh(reschedule_request)
+        except IntegrityError:
+            await session.rollback()
+            raise ValueError("По этой записи уже запрошен перенос")
+
+        return reschedule_request
+
+
+async def get_reschedule_requests_by_appointment(
+    appointment_id: UUID,
+    user_id: UUID,
+) -> list[AppointmentRescheduleRequest]:
+    async with get_async_db() as session:
+        appointment_result = await session.execute(
+            select(Appointment)
+            .outerjoin(Psychologist, Appointment.psychologist_id == Psychologist.id)
+            .where(
+                Appointment.id == appointment_id,
+                (
+                    (Appointment.patient_id == user_id)
+                    | (Psychologist.user_id == user_id)
+                ),
+            )
+        )
+        if appointment_result.scalar_one_or_none() is None:
+            raise ValueError("Встреча не найдена")
+
+        result = await session.execute(
+            select(AppointmentRescheduleRequest)
+            .where(AppointmentRescheduleRequest.appointment_id == appointment_id)
+            .order_by(AppointmentRescheduleRequest.created_at.desc())
+        )
+        return list(result.scalars().all())
+
+
+async def confirm_reschedule_request(
+    request_id: UUID,
+    patient_user_id: UUID,
+) -> AppointmentRescheduleRequest:
+    async with get_async_db() as session:
+        query = (
+            select(AppointmentRescheduleRequest)
+            .options(selectinload(AppointmentRescheduleRequest.appointment))
+            .where(AppointmentRescheduleRequest.id == request_id)
+            .with_for_update()
+        )
+        result = await session.execute(query)
+        reschedule_request = result.scalar_one_or_none()
+
+        if reschedule_request is None:
+            raise ValueError("Запрос переноса не найден")
+        if reschedule_request.status != AppointmentRescheduleStatus.pending:
+            raise ValueError("Запрос переноса уже обработан")
+
+        appointment = reschedule_request.appointment
+        if appointment.patient_id != patient_user_id:
+            raise PermissionError("Только пациент может подтвердить перенос")
+
+        _ensure_appointment_open(appointment)
+
+        now = datetime.now(timezone.utc)
+        appointment.scheduled_time = reschedule_request.requested_scheduled_time
+        appointment.remind_time = reschedule_request.requested_remind_time
+        if reschedule_request.requested_venue is not None:
+            appointment.venue = reschedule_request.requested_venue
+        if reschedule_request.requested_comment is not None:
+            appointment.comment = reschedule_request.requested_comment
+        appointment.last_change_time = now
+
+        reschedule_request.status = AppointmentRescheduleStatus.confirmed
+        reschedule_request.responded_at = now
+
+        await session.commit()
+        await session.refresh(reschedule_request)
+        return reschedule_request
+
+
+async def reject_reschedule_request(
+    request_id: UUID,
+    patient_user_id: UUID,
+    rejection_comment: str,
+) -> AppointmentRescheduleRequest:
+    async with get_async_db() as session:
+        query = (
+            select(AppointmentRescheduleRequest)
+            .options(selectinload(AppointmentRescheduleRequest.appointment))
+            .where(AppointmentRescheduleRequest.id == request_id)
+            .with_for_update()
+        )
+        result = await session.execute(query)
+        reschedule_request = result.scalar_one_or_none()
+
+        if reschedule_request is None:
+            raise ValueError("Запрос переноса не найден")
+        if reschedule_request.status != AppointmentRescheduleStatus.pending:
+            raise ValueError("Запрос переноса уже обработан")
+
+        appointment = reschedule_request.appointment
+        if appointment.patient_id != patient_user_id:
+            raise PermissionError("Только пациент может отклонить перенос")
+
+        _ensure_appointment_open(appointment)
+
+        reschedule_request.status = AppointmentRescheduleStatus.rejected
+        reschedule_request.rejection_comment = rejection_comment
+        reschedule_request.responded_at = datetime.now(timezone.utc)
+
+        await session.commit()
+        await session.refresh(reschedule_request)
+        return reschedule_request

--- a/psychohelp/repositories/appointments.py
+++ b/psychohelp/repositories/appointments.py
@@ -129,7 +129,8 @@ async def get_appointments_by_user_id(user_id: UUID) -> list[Appointment]:
 async def complete_appointment_by_psychologist(
         appointment_id: UUID,
         psychologist_id: UUID,
-        conclusion: str) -> Appointment:
+        patient_comment: str,
+        psychologist_comment: str | None = None) -> Appointment:
     async with get_async_db() as session:
         # Добавили selectinload для всех нужных связей
         query = select(Appointment).options(
@@ -148,7 +149,8 @@ async def complete_appointment_by_psychologist(
             raise ValueError("Нельзя завершить эту встречу (она уже завершена или отменена)")
 
         appointment.status = AppointmentStatus.done
-        appointment.conclusion = conclusion
+        appointment.conclusion = patient_comment
+        appointment.psychologist_comment = psychologist_comment
         appointment.last_change_time = datetime.now(timezone.utc)
 
         try:

--- a/psychohelp/routes/controllers/appointments.py
+++ b/psychohelp/routes/controllers/appointments.py
@@ -15,11 +15,22 @@ from psychohelp.services.appointments.appointments import (
     get_appointment_by_id,
     create_appointment as srv_create_appointment,
     cancel_appointment_by_member,
+    confirm_appointment_reschedule,
     get_appointments_by_user_id,
+    get_appointment_reschedule_requests,
+    reject_appointment_reschedule,
+    request_appointment_reschedule,
 )
 from psychohelp.services.appointments import exceptions as exc
-from psychohelp.schemas.appointments import AppointmentBase, AppointmentCreateRequest, AppointmentCancelRequest, \
-    AppointmentDoneRequest
+from psychohelp.schemas.appointments import (
+    AppointmentBase,
+    AppointmentCreateRequest,
+    AppointmentCancelRequest,
+    AppointmentDoneRequest,
+    AppointmentRescheduleRejectRequest,
+    AppointmentRescheduleRequestCreate,
+    AppointmentRescheduleRequestResponse,
+)
 from psychohelp.services.rbac.permissions import require_permission
 from psychohelp.constants.rbac import PermissionCode
 from psychohelp.dependencies.auth import get_current_user, get_optional_user
@@ -167,6 +178,100 @@ async def cancel_appointment(
     except ValueError as e:
         logger.error(f"Appointment cancellation failed: {str(e)}")
         raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.get("/{id}/reschedule-requests", response_model=list[AppointmentRescheduleRequestResponse])
+@require_permission(PermissionCode.APPOINTMENTS_VIEW_OWN)
+async def get_reschedule_requests(
+    id: UUID,
+    current_user: User = Depends(get_current_user),
+) -> list[AppointmentRescheduleRequestResponse]:
+    """Получить запросы переноса по записи"""
+    try:
+        return await get_appointment_reschedule_requests(id, current_user.id)
+    except ValueError as e:
+        raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=str(e))
+
+
+@router.post("/{id}/reschedule-requests", response_model=AppointmentRescheduleRequestResponse)
+@require_permission(PermissionCode.APPOINTMENTS_RESCHEDULE)
+async def request_reschedule(
+    id: UUID,
+    request: AppointmentRescheduleRequestCreate,
+    current_user: User = Depends(get_current_user),
+) -> AppointmentRescheduleRequestResponse:
+    """Запросить подтверждение переноса записи у пациента"""
+    try:
+        reschedule_request = await request_appointment_reschedule(
+            appointment_id=id,
+            psychologist_user_id=current_user.id,
+            scheduled_time=request.scheduled_time,
+            remind_time=request.remind_time,
+            venue=request.venue,
+            comment=request.comment,
+        )
+        logger.info(f"Appointment reschedule requested: {id} by psychologist: {current_user.id}")
+        return reschedule_request
+    except exc.InvalidScheduledTimeException:
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail="Время записи не может быть в прошлом",
+        )
+    except exc.InvalidRemindTimeException as e:
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail=f"Некорректное время напоминания: {e.reason}",
+        )
+    except PermissionError as e:
+        raise HTTPException(status_code=HTTP_403_FORBIDDEN, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.post(
+    "/reschedule-requests/{request_id}/confirm",
+    response_model=AppointmentRescheduleRequestResponse,
+)
+@require_permission(PermissionCode.APPOINTMENTS_CONFIRM_OWN)
+async def confirm_reschedule(
+    request_id: UUID,
+    current_user: User = Depends(get_current_user),
+) -> AppointmentRescheduleRequestResponse:
+    """Подтвердить перенос записи пациентом"""
+    try:
+        reschedule_request = await confirm_appointment_reschedule(request_id, current_user.id)
+        logger.info(f"Appointment reschedule confirmed: {request_id} by user: {current_user.id}")
+        return reschedule_request
+    except PermissionError as e:
+        raise HTTPException(status_code=HTTP_403_FORBIDDEN, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.post(
+    "/reschedule-requests/{request_id}/reject",
+    response_model=AppointmentRescheduleRequestResponse,
+)
+@require_permission(PermissionCode.APPOINTMENTS_CONFIRM_OWN)
+async def reject_reschedule(
+    request_id: UUID,
+    request: AppointmentRescheduleRejectRequest,
+    current_user: User = Depends(get_current_user),
+) -> AppointmentRescheduleRequestResponse:
+    """Отклонить перенос записи пациентом без отмены самой записи"""
+    try:
+        reschedule_request = await reject_appointment_reschedule(
+            request_id,
+            current_user.id,
+            request.rejection_comment,
+        )
+        logger.info(f"Appointment reschedule rejected: {request_id} by user: {current_user.id}")
+        return reschedule_request
+    except PermissionError as e:
+        raise HTTPException(status_code=HTTP_403_FORBIDDEN, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=str(e))
+
 
 @router.put("/{id}/done", summary="Завершить прием и написать заключение")
 async def complete_appointment_endpoint(

--- a/psychohelp/routes/controllers/appointments.py
+++ b/psychohelp/routes/controllers/appointments.py
@@ -273,7 +273,7 @@ async def reject_reschedule(
         raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=str(e))
 
 
-@router.put("/{id}/done", summary="Завершить прием и написать заключение")
+@router.put("/{id}/done", summary="Завершить прием и сохранить комментарии")
 async def complete_appointment_endpoint(
         id: UUID,
         request: AppointmentDoneRequest,
@@ -282,10 +282,15 @@ async def complete_appointment_endpoint(
     """
      Завершает запись на прием (переводит в статус Done).
      Доступно только психологу, который вел этот прием.
-     Требует обязательного заключения (conclusion).
+     Сохраняет комментарий пациенту и внутренний комментарий психологам.
      """
     try:
-        await complete_appointment(id, current_user.id, request.conclusion)
+        await complete_appointment(
+            id,
+            current_user.id,
+            request.patient_comment,
+            request.psychologist_comment,
+        )
         logger.info(f"Appointment completed: {id} by psychologist: {current_user.id}")
         return Response(None, status_code=HTTP_200_OK)
 

--- a/psychohelp/schemas/applications.py
+++ b/psychohelp/schemas/applications.py
@@ -46,6 +46,7 @@ class AppointmentFullResponse(BaseModel):
     reason: Optional[str] = None
     status: str
     cancel_reason: Optional[str] = None
+    patient_comment: Optional[str] = None
     conclusion: Optional[str] = None
     scheduled_time: datetime
     remind_time: Optional[datetime] = None

--- a/psychohelp/schemas/appointments.py
+++ b/psychohelp/schemas/appointments.py
@@ -3,7 +3,9 @@ from psychohelp.repositories.appointments import (
     AppointmentStatus,
     UUID,
 )
+from psychohelp.models.appointment_reschedule_requests import AppointmentRescheduleStatus
 from pydantic import BaseModel, EmailStr
+from pydantic import Field
 from datetime import datetime
 from typing import Optional
 
@@ -87,3 +89,36 @@ class AppointmentCancelRequest(BaseModel):
 
 class AppointmentDoneRequest(BaseModel):
     conclusion: str
+
+
+class AppointmentRescheduleRequestCreate(BaseModel):
+    scheduled_time: datetime
+    remind_time: Optional[datetime] = None
+    venue: Optional[str] = Field(None, min_length=1, max_length=128)
+    comment: Optional[str] = Field(None, max_length=512)
+
+
+class AppointmentRescheduleRejectRequest(BaseModel):
+    rejection_comment: str = Field(..., min_length=1, max_length=512)
+
+
+class AppointmentRescheduleRequestResponse(BaseModel):
+    id: UUID
+    appointment_id: UUID
+    requested_by_user_id: Optional[UUID] = None
+    status: AppointmentRescheduleStatus
+    old_scheduled_time: datetime
+    old_remind_time: Optional[datetime] = None
+    old_venue: str
+    old_comment: Optional[str] = None
+    requested_scheduled_time: datetime
+    requested_remind_time: Optional[datetime] = None
+    requested_venue: Optional[str] = None
+    requested_comment: Optional[str] = None
+    rejection_comment: Optional[str] = None
+    created_at: datetime
+    responded_at: Optional[datetime] = None
+
+    class Config:
+        from_attributes = True
+        use_enum_values = True

--- a/psychohelp/schemas/appointments.py
+++ b/psychohelp/schemas/appointments.py
@@ -4,8 +4,7 @@ from psychohelp.repositories.appointments import (
     UUID,
 )
 from psychohelp.models.appointment_reschedule_requests import AppointmentRescheduleStatus
-from pydantic import BaseModel, EmailStr
-from pydantic import Field
+from pydantic import AliasChoices, BaseModel, EmailStr, Field
 from datetime import datetime
 from typing import Optional
 
@@ -64,6 +63,7 @@ class AppointmentBase(BaseModel):
     venue: str
     comment: Optional[str] = None
     cancel_reason: Optional[str] = None
+    patient_comment: Optional[str] = None
     conclusion: Optional[str] = None
 
     class Config:
@@ -88,7 +88,13 @@ class AppointmentCancelRequest(BaseModel):
 
 
 class AppointmentDoneRequest(BaseModel):
-    conclusion: str
+    patient_comment: str = Field(
+        ...,
+        min_length=1,
+        max_length=2048,
+        validation_alias=AliasChoices("patient_comment", "conclusion"),
+    )
+    psychologist_comment: Optional[str] = Field(None, max_length=2048)
 
 
 class AppointmentRescheduleRequestCreate(BaseModel):

--- a/psychohelp/services/appointments/appointments.py
+++ b/psychohelp/services/appointments/appointments.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 from uuid import UUID
 
 from psychohelp.repositories import get_user_id_from_token
+from psychohelp.repositories import appointment_reschedule_requests as reschedule_repo
 from psychohelp.repositories.appointments import (
     get_appointment_by_id as repo_get_appointment_by_id,
     create_appointment as repo_create_appointment,
@@ -18,6 +19,36 @@ from psychohelp.models.appointments import Appointment, AppointmentType, Appoint
 from psychohelp.services.appointments import exceptions as exc
 from psychohelp.services.applications.applications import confirm_application
 from psychohelp.repositories.appointments import cancel_appointment_by_id as repo_cancel
+
+
+def _as_utc(value: datetime) -> datetime:
+    return value.astimezone(timezone.utc) if value.tzinfo else value.replace(tzinfo=timezone.utc)
+
+
+def _validate_appointment_time(
+    scheduled_time: datetime,
+    remind_time: datetime | None,
+) -> tuple[datetime, datetime | None]:
+    now = datetime.now(timezone.utc)
+    scheduled_time_utc = _as_utc(scheduled_time)
+    if scheduled_time_utc <= now:
+        raise exc.InvalidScheduledTimeException(scheduled_time)
+
+    remind_time_utc = None
+    if remind_time is not None:
+        remind_time_utc = _as_utc(remind_time)
+        if remind_time_utc <= now:
+            raise exc.InvalidRemindTimeException(
+                remind_time,
+                "время напоминания не может быть в прошлом",
+            )
+        if remind_time_utc >= scheduled_time_utc:
+            raise exc.InvalidRemindTimeException(
+                remind_time,
+                "время напоминания должно быть раньше времени встречи",
+            )
+
+    return scheduled_time_utc, remind_time_utc
 
 
 async def get_appointment_by_id(appointment_id: UUID, user_id: UUID) -> Appointment | None:
@@ -38,16 +69,7 @@ async def create_appointment(
     now = datetime.now(timezone.utc)
     status = AppointmentStatus.awaiting
 
-    scheduled_time_utc = scheduled_time.astimezone(timezone.utc) if scheduled_time.tzinfo else scheduled_time.replace(tzinfo=timezone.utc)
-    if scheduled_time_utc <= now:
-        raise exc.InvalidScheduledTimeException(scheduled_time)
-
-    if remind_time is not None:
-        remind_time_utc = remind_time.astimezone(timezone.utc) if remind_time.tzinfo else remind_time.replace(tzinfo=timezone.utc)
-        if remind_time_utc <= now:
-            raise exc.InvalidRemindTimeException(remind_time, "время напоминания не может быть в прошлом")
-        if remind_time_utc >= scheduled_time_utc:
-            raise exc.InvalidRemindTimeException(remind_time, "время напоминания должно быть раньше времени встречи")
+    scheduled_time_utc, remind_time_utc = _validate_appointment_time(scheduled_time, remind_time)
 
     patient = await get_user_by_id(patient_id)
     if patient is None:
@@ -79,8 +101,8 @@ async def create_appointment(
         type=type,
         reason=reason,
         status=status,
-        scheduled_time=scheduled_time,
-        remind_time=remind_time,
+        scheduled_time=scheduled_time_utc,
+        remind_time=remind_time_utc,
         last_change_time=now,
         venue=venue,
         comment=comment,
@@ -131,3 +153,54 @@ async def complete_appointment(
     from psychohelp.repositories.appointments import complete_appointment_by_psychologist as repo_complete
     appointment = await repo_complete(appointment_id, psychologist_id, conclusion)
     return appointment
+
+
+async def request_appointment_reschedule(
+    appointment_id: UUID,
+    psychologist_user_id: UUID,
+    scheduled_time: datetime,
+    remind_time: datetime | None = None,
+    venue: str | None = None,
+    comment: str | None = None,
+):
+    scheduled_time_utc, remind_time_utc = _validate_appointment_time(scheduled_time, remind_time)
+    return await reschedule_repo.create_reschedule_request(
+        appointment_id=appointment_id,
+        psychologist_user_id=psychologist_user_id,
+        scheduled_time=scheduled_time_utc,
+        remind_time=remind_time_utc,
+        venue=venue,
+        comment=comment,
+    )
+
+
+async def get_appointment_reschedule_requests(
+    appointment_id: UUID,
+    user_id: UUID,
+):
+    return await reschedule_repo.get_reschedule_requests_by_appointment(
+        appointment_id=appointment_id,
+        user_id=user_id,
+    )
+
+
+async def confirm_appointment_reschedule(
+    request_id: UUID,
+    patient_user_id: UUID,
+):
+    return await reschedule_repo.confirm_reschedule_request(
+        request_id=request_id,
+        patient_user_id=patient_user_id,
+    )
+
+
+async def reject_appointment_reschedule(
+    request_id: UUID,
+    patient_user_id: UUID,
+    rejection_comment: str,
+):
+    return await reschedule_repo.reject_reschedule_request(
+        request_id=request_id,
+        patient_user_id=patient_user_id,
+        rejection_comment=rejection_comment,
+    )

--- a/psychohelp/services/appointments/appointments.py
+++ b/psychohelp/services/appointments/appointments.py
@@ -149,9 +149,15 @@ async def get_appointment_for_user(appointment_id: UUID, user_id: UUID) -> Appoi
 async def complete_appointment(
         appointment_id: UUID,
         psychologist_id: UUID,
-        conclusion: str) -> Appointment:
+        patient_comment: str,
+        psychologist_comment: str | None = None) -> Appointment:
     from psychohelp.repositories.appointments import complete_appointment_by_psychologist as repo_complete
-    appointment = await repo_complete(appointment_id, psychologist_id, conclusion)
+    appointment = await repo_complete(
+        appointment_id,
+        psychologist_id,
+        patient_comment,
+        psychologist_comment,
+    )
     return appointment
 
 

--- a/tests/test_appointment_completion_comments.py
+++ b/tests/test_appointment_completion_comments.py
@@ -1,0 +1,94 @@
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from psychohelp.models.appointments import AppointmentStatus
+from psychohelp.repositories import appointments as appointments_repo
+from psychohelp.schemas.appointments import AppointmentBase, AppointmentDoneRequest
+
+
+class FakeScalarResult:
+    def __init__(self, value):
+        self.value = value
+
+    def scalar_one_or_none(self):
+        return self.value
+
+
+class FakeSession:
+    def __init__(self, appointment):
+        self.appointment = appointment
+        self.committed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def execute(self, _query):
+        return FakeScalarResult(self.appointment)
+
+    async def commit(self):
+        self.committed = True
+
+    async def rollback(self):
+        pass
+
+
+class FakeDb:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_complete_appointment_stores_patient_and_psychologist_comments(monkeypatch):
+    psychologist_user_id = uuid4()
+    appointment = SimpleNamespace(
+        id=uuid4(),
+        psychologist=SimpleNamespace(user_id=psychologist_user_id),
+        status=AppointmentStatus.awaiting,
+        conclusion=None,
+        psychologist_comment=None,
+        last_change_time=None,
+    )
+    session = FakeSession(appointment)
+
+    monkeypatch.setattr(appointments_repo, "get_async_db", lambda: FakeDb(session))
+
+    result = await appointments_repo.complete_appointment_by_psychologist(
+        appointment.id,
+        psychologist_user_id,
+        "Комментарий пациенту",
+        "Комментарий психологам",
+    )
+
+    assert result is appointment
+    assert session.committed is True
+    assert appointment.status == AppointmentStatus.done
+    assert appointment.conclusion == "Комментарий пациенту"
+    assert appointment.psychologist_comment == "Комментарий психологам"
+    assert appointment.last_change_time is not None
+
+
+def test_appointment_done_request_accepts_legacy_conclusion_alias():
+    request = AppointmentDoneRequest.model_validate(
+        {
+            "conclusion": "Старое поле для пациента",
+            "psychologist_comment": "Внутренняя заметка",
+        }
+    )
+
+    assert request.patient_comment == "Старое поле для пациента"
+    assert request.psychologist_comment == "Внутренняя заметка"
+
+
+def test_internal_psychologist_comment_is_not_in_shared_appointment_response():
+    assert "psychologist_comment" not in AppointmentBase.model_fields

--- a/tests/test_appointment_reschedules.py
+++ b/tests/test_appointment_reschedules.py
@@ -1,0 +1,214 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from psychohelp.models.appointment_reschedule_requests import (
+    AppointmentRescheduleStatus,
+)
+from psychohelp.models.appointments import AppointmentStatus
+from psychohelp.repositories import appointment_reschedule_requests as reschedule_repo
+from psychohelp.services.appointments import appointments as appointments_service
+from psychohelp.services.appointments import exceptions as appointment_exceptions
+
+
+@pytest.mark.asyncio
+async def test_request_appointment_reschedule_normalizes_and_delegates(monkeypatch):
+    appointment_id = uuid4()
+    psychologist_user_id = uuid4()
+    scheduled_time = datetime.now(timezone.utc) + timedelta(days=1)
+    remind_time = scheduled_time - timedelta(hours=1)
+    captured = {}
+
+    async def fake_create_reschedule_request(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(id=uuid4())
+
+    monkeypatch.setattr(
+        appointments_service.reschedule_repo,
+        "create_reschedule_request",
+        fake_create_reschedule_request,
+    )
+
+    result = await appointments_service.request_appointment_reschedule(
+        appointment_id=appointment_id,
+        psychologist_user_id=psychologist_user_id,
+        scheduled_time=scheduled_time,
+        remind_time=remind_time,
+        venue="Кабинет 1",
+        comment="Нужно перенести",
+    )
+
+    assert result.id
+    assert captured["appointment_id"] == appointment_id
+    assert captured["psychologist_user_id"] == psychologist_user_id
+    assert captured["scheduled_time"].tzinfo == timezone.utc
+    assert captured["remind_time"].tzinfo == timezone.utc
+    assert captured["venue"] == "Кабинет 1"
+    assert captured["comment"] == "Нужно перенести"
+
+
+@pytest.mark.asyncio
+async def test_request_appointment_reschedule_rejects_past_time(monkeypatch):
+    async def fake_create_reschedule_request(**_kwargs):
+        raise AssertionError("repository should not be called")
+
+    monkeypatch.setattr(
+        appointments_service.reschedule_repo,
+        "create_reschedule_request",
+        fake_create_reschedule_request,
+    )
+
+    with pytest.raises(appointment_exceptions.InvalidScheduledTimeException):
+        await appointments_service.request_appointment_reschedule(
+            appointment_id=uuid4(),
+            psychologist_user_id=uuid4(),
+            scheduled_time=datetime.now(timezone.utc) - timedelta(minutes=1),
+        )
+
+
+class FakeScalarResult:
+    def __init__(self, value):
+        self.value = value
+
+    def scalar_one_or_none(self):
+        return self.value
+
+
+class FakeSession:
+    def __init__(self, result):
+        self.result = result
+        self.committed = False
+        self.refreshed = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def execute(self, _query):
+        return FakeScalarResult(self.result)
+
+    async def commit(self):
+        self.committed = True
+
+    async def refresh(self, obj):
+        self.refreshed = obj
+
+
+class FakeDb:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_confirm_reschedule_request_applies_changes(monkeypatch):
+    patient_id = uuid4()
+    new_time = datetime.now(timezone.utc) + timedelta(days=2)
+    appointment = SimpleNamespace(
+        patient_id=patient_id,
+        status=AppointmentStatus.awaiting,
+        scheduled_time=datetime.now(timezone.utc) + timedelta(days=1),
+        remind_time=None,
+        venue="Старый кабинет",
+        comment="Старый комментарий",
+        last_change_time=datetime.now(timezone.utc),
+    )
+    reschedule_request = SimpleNamespace(
+        id=uuid4(),
+        status=AppointmentRescheduleStatus.pending,
+        appointment=appointment,
+        requested_scheduled_time=new_time,
+        requested_remind_time=None,
+        requested_venue="Новый кабинет",
+        requested_comment="Новый комментарий",
+        responded_at=None,
+    )
+    session = FakeSession(reschedule_request)
+
+    monkeypatch.setattr(reschedule_repo, "get_async_db", lambda: FakeDb(session))
+
+    result = await reschedule_repo.confirm_reschedule_request(
+        reschedule_request.id,
+        patient_id,
+    )
+
+    assert result is reschedule_request
+    assert session.committed is True
+    assert appointment.scheduled_time == new_time
+    assert appointment.venue == "Новый кабинет"
+    assert appointment.comment == "Новый комментарий"
+    assert reschedule_request.status == AppointmentRescheduleStatus.confirmed
+    assert reschedule_request.responded_at is not None
+
+
+@pytest.mark.asyncio
+async def test_reject_reschedule_request_does_not_change_appointment(monkeypatch):
+    patient_id = uuid4()
+    old_time = datetime.now(timezone.utc) + timedelta(days=1)
+    appointment = SimpleNamespace(
+        patient_id=patient_id,
+        status=AppointmentStatus.awaiting,
+        scheduled_time=old_time,
+        remind_time=None,
+        venue="Старый кабинет",
+        comment="Старый комментарий",
+    )
+    reschedule_request = SimpleNamespace(
+        id=uuid4(),
+        status=AppointmentRescheduleStatus.pending,
+        appointment=appointment,
+        rejection_comment=None,
+        responded_at=None,
+    )
+    session = FakeSession(reschedule_request)
+
+    monkeypatch.setattr(reschedule_repo, "get_async_db", lambda: FakeDb(session))
+
+    result = await reschedule_repo.reject_reschedule_request(
+        reschedule_request.id,
+        patient_id,
+        "Не подходит время",
+    )
+
+    assert result is reschedule_request
+    assert session.committed is True
+    assert appointment.scheduled_time == old_time
+    assert appointment.venue == "Старый кабинет"
+    assert appointment.comment == "Старый комментарий"
+    assert reschedule_request.status == AppointmentRescheduleStatus.rejected
+    assert reschedule_request.rejection_comment == "Не подходит время"
+    assert reschedule_request.responded_at is not None
+
+
+@pytest.mark.asyncio
+async def test_reject_reschedule_request_forbids_non_patient(monkeypatch):
+    appointment = SimpleNamespace(
+        patient_id=uuid4(),
+        status=AppointmentStatus.awaiting,
+    )
+    reschedule_request = SimpleNamespace(
+        id=uuid4(),
+        status=AppointmentRescheduleStatus.pending,
+        appointment=appointment,
+    )
+    session = FakeSession(reschedule_request)
+
+    monkeypatch.setattr(reschedule_repo, "get_async_db", lambda: FakeDb(session))
+
+    with pytest.raises(PermissionError):
+        await reschedule_repo.reject_reschedule_request(
+            reschedule_request.id,
+            uuid4(),
+            "Не подходит время",
+        )
+
+    assert session.committed is False


### PR DESCRIPTION
- Добавлен перенос записей с подтверждением/отклонением пациентом.
- Добавлены два комментария при завершении записи:
  - комментарий пациенту;
  - внутренний комментарий для психологов.
 
- Психолог может запросить перенос записи на другую дату/время.
- Пациент может подтвердить или отклонить перенос с комментарием.
- При отклонении переноса сама запись не отменяется и не изменяется.
- Завершение записи теперь принимает:
  - `patient_comment`;
  - `psychologist_comment`.
- `patient_comment` совместим с существующим полем `conclusion`.
- `psychologist_comment` хранится отдельно и не отдаётся в общем ответе записи.